### PR TITLE
Added easily switchable manufacturer and device IDs' API (#FNa command).

### DIFF
--- a/Src/fanet/fmac.cpp
+++ b/Src/fanet/fmac.cpp
@@ -104,6 +104,28 @@ bool FanetMac::eraseAddr(void)
 	return (ret == HAL_OK && sectorError == UINT32_MAX);
 }
 
+#ifdef MAC_SWITCHABLE
+bool FanetMac::writeVolatileAddr(FanetMacAddr addr)
+{
+	/* test for initialized storage, work with volatile MAC only if valid non-volatile MAC is available */
+	if(*(__IO uint64_t*)MAC_ADDR_BASE == UINT64_MAX)
+		return false;
+	_addr = addr;
+
+	return true;
+}
+
+bool FanetMac::eraseVolatileAddr(void)
+{
+	/* test for initialized storage, work with volatile MAC only if valid non-volatile MAC is available */
+	if(*(__IO uint64_t*)MAC_ADDR_BASE == UINT64_MAX)
+		return false;
+	/* simply return back to non-volatile addr*/
+	_addr = readAddr();
+	return true;
+}
+#endif
+
 /* this is executed in a non-linear fashion */
 void FanetMac::receivedBuffer2Frame(int length)
 {

--- a/Src/fanet/fmac.h
+++ b/Src/fanet/fmac.h
@@ -70,6 +70,9 @@
 #define MAC_ADDR_MAGIC				0x1337000000000000ULL
 #define MAC_ADDR_MAGIC_MASK			0xFFFF000000000000ULL
 
+//if defined, will add #FNa command with easily reconfigurable volatile manufacturer and device IDs.
+#define MAC_SWITCHABLE
+
 /* Debug */
 #define MAC_debug_mode				0
 #if !defined(DEBUG) && MAC_debug_mode > 0
@@ -163,6 +166,11 @@ public:
 	bool eraseAddr(void);
 	FanetMacAddr readAddr();
 	bool isAddrStored(void) { return *(__IO uint64_t*)MAC_ADDR_BASE != UINT64_MAX; }
+#ifdef MAC_SWITCHABLE
+	/* volatile MaC addr api */
+	bool eraseVolatileAddr(void);
+	bool writeVolatileAddr(FanetMacAddr addr);
+#endif
 };
 
 extern FanetMac fmac;

--- a/Src/serial/serial_interface.cpp
+++ b/Src/serial/serial_interface.cpp
@@ -46,6 +46,112 @@ void wire_task(void const * argument)
 
 /* Fanet Commands */
 
+#ifdef MAC_SWITCHABLE
+/* Address: #FNA manufacturer(hex),id(hex) */
+void Serial_Interface::fanet_cmd_addr(char *ch_str)
+{
+#if defined(DEBUG) && (SERIAL_debug_mode > 0)
+	printf("### Addr %s\n", ch_str);
+#endif
+	/* remove \r\n and any spaces*/
+	char *ptr = strchr(ch_str, '\r');
+	if(ptr == nullptr)
+		ptr = strchr(ch_str, '\n');
+	if(ptr != nullptr)
+		*ptr = '\0';
+	while(*ch_str == ' ')
+		ch_str++;
+
+	if(strlen(ch_str) == 0)
+	{
+		/* report addr */
+		char buf[64];
+		//take addr directly from flash, not from RAM copy
+		snprintf(buf, sizeof(buf), "%s%c %02X,%04X\n", FANET_CMD_START, CMD_ADDR, fmac.readAddr().manufacturer, fmac.readAddr().id);
+		print(buf);
+		return;
+	}
+
+	if(strstr(ch_str, "ERASE!") != NULL)
+	{
+		/* erase config */
+		//must never be used by the end user
+		if(fmac.eraseAddr())
+			print_line(FN_REPLY_OK);
+		else
+			print_line(FN_REPLYE_FN_UNKNOWN_CMD);
+		return;
+	}
+
+	/* address */
+	char *p = (char *)ch_str;
+	int manufacturer = strtol(p, NULL, 16);
+	p = strchr(p, SEPARATOR)+1;
+	int id = strtol(p, NULL, 16);
+
+	if(manufacturer<=0 || manufacturer >= 0xFE || id <= 0 || id >= 0xFFFF)
+	{
+		print_line(FN_REPLYE_INVALID_ADDR);
+	}
+	else if(fmac.writeAddr(FanetMacAddr(manufacturer, id)))
+		print_line(FN_REPLY_OK);
+	else
+		print_line(FN_REPLYE_ADDR_GIVEN);
+}
+
+/* Address: #FNa manufacturer(hex),id(hex).
+ * Controls volatile (which reset after power loss) manufacturer(hex) and id(hex) values. */
+void Serial_Interface::fanet_cmd_vaddr(char *ch_str)
+{
+#if defined(DEBUG) && (SERIAL_debug_mode > 0)
+	printf("### Volatile addr %s\n", ch_str);
+#endif
+	/* remove \r\n and any spaces*/
+	char *ptr = strchr(ch_str, '\r');
+	if(ptr == nullptr)
+		ptr = strchr(ch_str, '\n');
+	if(ptr != nullptr)
+		*ptr = '\0';
+	while(*ch_str == ' ')
+		ch_str++;
+
+	if(strlen(ch_str) == 0)
+	{
+		/* report addr */
+		char buf[64];
+		snprintf(buf, sizeof(buf), "%s%c %02X,%04X\n", FANET_CMD_START, CMD_ADDR, fmac.addr.manufacturer, fmac.addr.id);
+		print(buf);
+		return;
+	}
+
+	if(strstr(ch_str, "ERASE!") != NULL)
+	{
+		/* erase volatile config, which means simple switch back to non-volatile values */
+		if(fmac.eraseVolatileAddr())
+			print_line(FN_REPLY_OK);
+		else
+			print_line(FN_REPLYE_FN_UNKNOWN_CMD);
+		return;
+	}
+
+	/* address */
+	char *p = (char *)ch_str;
+	int manufacturer = strtol(p, NULL, 16);
+	p = strchr(p, SEPARATOR)+1;
+	int id = strtol(p, NULL, 16);
+
+	if(manufacturer<=0 || manufacturer >= 0xFE || id <= 0 || id >= 0xFFFF)
+	{
+		print_line(FN_REPLYE_INVALID_ADDR);
+	}
+	else if(fmac.writeVolatileAddr(FanetMacAddr(manufacturer, id)))
+		print_line(FN_REPLY_OK);
+	else
+		print_line(FN_REPLYE_FN_UNKNOWN_CMD);
+}
+
+#else
+
 /* Address: #FNA manufacturer(hex),id(hex) */
 void Serial_Interface::fanet_cmd_addr(char *ch_str)
 {
@@ -96,6 +202,8 @@ void Serial_Interface::fanet_cmd_addr(char *ch_str)
 	else
 		print_line(FN_REPLYE_ADDR_GIVEN);
 }
+
+#endif
 
 /* Transmit: #FNT type,dest_manufacturer,dest_id,forward,ack_required,length,length*2hex[,signature] */
 //note: all in HEX
@@ -564,6 +672,11 @@ void Serial_Interface::fanet_cmd_eval(char *str)
 	case CMD_ADDR:
 		fanet_cmd_addr(&str[strlen(FANET_CMD_START) + 1]);
 		break;
+#ifdef MAC_SWITCHABLE
+	case CMD_VOLATILE_ADDR:
+		fanet_cmd_vaddr(&str[strlen(FANET_CMD_START) + 1]);
+		break;
+#endif
 	case CMD_NEIGHBOR:
 		fanet_cmd_neighbor(&str[strlen(FANET_CMD_START) + 1]);
 		break;

--- a/Src/serial/serial_interface.h
+++ b/Src/serial/serial_interface.h
@@ -60,6 +60,9 @@ void wire_task(void const * argument);
 #define CMD_STATE			'S'
 #define CMD_TRANSMIT			'T'
 #define CMD_ADDR			'A'
+#ifdef MAC_SWITCHABLE
+#define CMD_VOLATILE_ADDR		'a'
+#endif
 #define CMD_CONFIG			'C'
 #define CMD_MODE			'M'
 #define CMD_NEIGHBOR			'N'
@@ -159,6 +162,9 @@ private:
 	/* Normal Commands */
 	void fanet_cmd_eval(char *str);
 	void fanet_cmd_addr(char *ch_str);
+#ifdef MAC_SWITCHABLE
+	void fanet_cmd_vaddr(char *ch_str);
+#endif
 	void fanet_cmd_transmit(char *ch_str);
 	void fanet_cmd_neighbor(char *ch_str);
 	void fanet_cmd_promiscuous(char *ch_str);


### PR DESCRIPTION
This functionality is experimental and can be activated by MAC_SWITCHABLE define during compilation. Functional changes: 
1) added new "#FNa", "#FNa ERASE!" and "#FNa ManufacturerID, UniqueID" commands used to control volatile manufacturer and device IDs. #FNa returns currently used volatile values; 
2) by default after power up configured in flash IDs are used; 
3) new functionality can be activated/deactivated (conditional compilation) in the code by MAC_SWITCHABLE define in fmac.h file; 
4) switch back to flash IDs happens after "#FNa ERASE!"(returns back to preconfigured in flash values) or "#FNA ManufacturerID, UniqueID"(sets new flash values and makes them active) commands; 
5) temporary IDs functionality is available only if default IDs in flash are already configured (work without configured in flash IDs is disabled because it means that device is not fully configured yet).